### PR TITLE
V1.9.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,10 +33,15 @@ test:
 
 about:
   home: https://github.com/coady/multimethod
+  description: |
+    Multimethod provides a decorator for adding multiple argument dispatching to functions. 
+    The decorator creates a multimethod object as needed, and registers the function 
+    with its annotations.
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE.txt
   summary: Multiple argument dispatching.
+  dev_url: https://github.com/coady/multimethod
   doc_url: https://multimethod.readthedocs.io/en/latest/
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,9 @@ build:
 requirements:
   host:
     - pip
-    - python 
+    - python
+    - setuptools
+    - wheel
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,10 @@ requirements:
 test:
   imports:
     - multimethod
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/coady/multimethod

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,15 +11,15 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python 
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "multimethod" %}
-{% set version = "1.5" %}
+{% set version = "1.9.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b9c6f85ecf187f14a3951fff319643e1fac3086d757dec64f2469e1fd136b65d
+  sha256: 1589bf52ca294667fd15527ea830127c763f5bfc38562e3642591ffd0fd9d56f
 
 build:
   number: 0


### PR DESCRIPTION
[Upstream](https://github.com/coady/multimethod/tree/v1.9.1)
[Changelog](https://coady.github.io/multimethod/#changes)

### Actions
- Updated version to `1.9.1`
- Changed build from `noarch` to `skip: true [py<37]`
- Add `pip check` to test section
- linter fixes